### PR TITLE
Add groupid functioning as foreign key

### DIFF
--- a/db/install.xml
+++ b/db/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="blocks/groups/db" VERSION="20120122" COMMENT="XMLDB file for Moodle blocks/groups"
+<XMLDB PATH="blocks/groups/db" VERSION="20251001" COMMENT="XMLDB file for Moodle blocks/groups"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:noNamespaceSchemaLocation="../../../lib/xmldb/xmldb.xsd"
 >
@@ -10,7 +10,6 @@
             </FIELDS>
             <KEYS>
                 <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
-                <KEY NAME="foreign" TYPE="foreign" FIELDS="id" REFTABLE="groups" REFFIELDS="id"/>
             </KEYS>
         </TABLE>
     </TABLES>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -29,5 +29,20 @@
 
  */
 function xmldb_block_groups_upgrade($oldversion) {
-    return true;
+    global $DB;
+
+    $dbman = $DB->get_manager();
+
+    if ($oldversion < 2025100100) {
+        $table = new xmldb_table('block_groups_hide');
+
+        // Define key id (foreign) to be dropped form block_groups_hide.
+        $key = new xmldb_key('foreign', XMLDB_KEY_FOREIGN, ['id'], 'groups', ['id']);
+
+        // Launch drop key id. There is no key_exists method.
+        $dbman->drop_key($table, $key);
+
+        // Grade_me savepoint reached.
+        upgrade_block_savepoint(true, 2025100100, 'groups');
+    }
 }

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 
-$plugin->version   = 2025091700;     // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2025100100;     // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2022112800;     // Requires 4.1+ Moodle version.
 $plugin->component = 'block_groups'; // Full name of the plugin (used for diagnostics).
 $plugin->release = 'v5.0-r1';


### PR DESCRIPTION
The `check_database_schema` is reporting the schema issue which is `mdl_blocgrouhide_id_ix` is missing. 
However, the database inspection shows that  a index does actually already exist, however instead of the expected name mdl_blocgrouhide_id_ix it is actually called mdl_blocgrouhide_id3_ix
```
eworks=# \d mdl_block_groups_hide 
       Table "public.mdl_block_groups_hide"
 Column |  Type  | Collation | Nullable | Default 
--------+--------+-----------+----------+---------
 id     | bigint |           | not null | 
Indexes:
    "mdl_blocgrouhide_id_pk" PRIMARY KEY, btree (id)
    "mdl_blocgrouhide_id2_ix" btree (id)
    "mdl_blocgrouhide_id3_ix" btree (id)
 ```
 The `check_database_schema --fix` could not fix this issue the new index mdl_blocgrouhide_id4_ix was created instead of `mdl_blocgrouhide_id_ix` and it still display the issue.
 
```
eworks=# \d mdl_block_groups_hide 
       Table "public.mdl_block_groups_hide"
 Column |  Type  | Collation | Nullable | Default 
--------+--------+-----------+----------+---------
 id     | bigint |           | not null | 
Indexes:
    "mdl_blocgrouhide_id_pk" PRIMARY KEY, btree (id)
    "mdl_blocgrouhide_id2_ix" btree (id)
    "mdl_blocgrouhide_id3_ix" btree (id)
    "mdl_blocgrouhide_id4_ix" btree (id)
```

The same issue also appears on block_grade_me (see [here](https://github.com/remotelearner/moodle-block_grade_me/issues/81) ).  So this PR applies the same approach to solve it.
